### PR TITLE
feat: get leaderboard initial fetch

### DIFF
--- a/apps/microgame/src/app/(payload)/page.tsx
+++ b/apps/microgame/src/app/(payload)/page.tsx
@@ -1,20 +1,17 @@
-"use client";
-
-import FuelProviderWrapper from "@/shared/ui/Terminal/FuelProviderWrapper";
-import {QueryClientProvider} from "@tanstack/react-query";
-import {queryClient} from "@/shared/lib/queryClient";
-import Terminal from "@/shared/ui/Terminal/Terminal";
+import TerminalPage from "@/shared/ui/Terminal/TerminalPage";
+import { getLeaderboard } from "@/api/microgame/leaderboard";
 
 import "@/shared/ui/index.css";
 
 export default function Home() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <FuelProviderWrapper>
-        <div className="min-h-screen w-full flex items-center justify-center bg-black font-['VT323',monospace]">
-          <Terminal />
-        </div>
-      </FuelProviderWrapper>
-    </QueryClientProvider>
+    <TerminalDataWrapper />
+  );
+}
+
+async function TerminalDataWrapper() {
+  const leaderboard = await getLeaderboard();
+  return (
+    <TerminalPage leaderBoardData={leaderboard} />
   );
 }

--- a/libs/api/microgame/leaderboard.ts
+++ b/libs/api/microgame/leaderboard.ts
@@ -1,0 +1,57 @@
+import axios from "axios";
+
+const BASE_URL =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:8000"
+    : "https://microchain.systems";
+
+const API_URL = `${BASE_URL}/api/globals/leaderboard`;
+// const API_URL = `${BASE_URL}/api/globals/leaderboard?select[id]=true&select[user][walletAddress]=true&select[score]=true`;
+
+export const getLeaderboard = async () => {
+  try {
+    const response = await axios.get(API_URL, {
+      params: {
+        depth: 4,
+        draft: false,
+      },
+    });
+
+    const entries = response.data?.entries || [];
+    console.log(entries);
+    return (
+      entries
+        //   .filter((entry: any) => entry.user?.walletAddress && entry.score)
+        .map((entry: any) => ({
+          id: entry.id,
+          walletAddress: entry.user,
+          score: entry.score,
+        }))
+    );
+  } catch (err) {
+    console.error("Failed to fetch leaderboard:", err);
+    throw err;
+  }
+};
+
+export const updateLeaderboard = async (
+  entries: Array<{user: string; score: number; gameData?: any}>,
+  token: string,
+) => {
+  try {
+    const response = await axios.post(
+      API_URL,
+      {entries},
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    return response.data;
+  } catch (err) {
+    console.error("Failed to update leaderboard:", err);
+    throw err;
+  }
+};

--- a/libs/shared/hooks/useTerminal.ts
+++ b/libs/shared/hooks/useTerminal.ts
@@ -1,5 +1,6 @@
 import {useState, useRef, useEffect, useCallback} from "react";
 import {COMMANDS, CORRECT_PASSWORD, HELP_TEXT} from "../lib/constants";
+import crypto from "crypto";
 import {get} from "http";
 
 export type TerminalView =
@@ -20,7 +21,7 @@ interface TerminalState {
   multiplier: number;
   gameActive: boolean;
   walletAddress: string;
-  leaderboard: {wallet: string; score: number}[];
+  leaderboard: {id: string; wallet: string; score: number}[];
 }
 
 const getLocalStorageHighScore = () => {
@@ -29,7 +30,7 @@ const getLocalStorageHighScore = () => {
   return highScore ? parseInt(highScore) : 0;
 };
 
-export function useTerminal() {
+export function useTerminal({leaderBoardData}: any) {
   const [state, setState] = useState<TerminalState>({
     isAuthenticated: false,
     currentView: "boot",
@@ -40,11 +41,7 @@ export function useTerminal() {
     multiplier: 1,
     gameActive: false,
     walletAddress: "",
-    leaderboard: [
-      {wallet: "0x1a2b...3c4d", score: 15750},
-      {wallet: "0x7e8f...9a0b", score: 12320},
-      {wallet: "0x4d5e...6f7g", score: 9845},
-    ],
+    leaderboard: leaderBoardData,
   });
 
   const commandInputRef = useRef<HTMLInputElement>(null);
@@ -213,7 +210,11 @@ export function useTerminal() {
         // Create a new leaderboard with the current wallet/score
         const newLeaderboard = [
           ...prevState.leaderboard,
-          {wallet: wallet, score: prevState.currentScore},
+          {
+            id: crypto.randomBytes(16).toString("hex"),
+            wallet: wallet,
+            score: prevState.currentScore,
+          },
         ]
           .sort((a, b) => b.score - a.score)
           .slice(0, 10); // Keep top 10

--- a/libs/shared/ui/Terminal/MiniGame.tsx
+++ b/libs/shared/ui/Terminal/MiniGame.tsx
@@ -1,9 +1,9 @@
-import {useState, useEffect} from "react";
-import {GAME_INSTRUCTIONS} from "../../lib/constants";
-import {PaginationContextProvider} from "../Pagination/PaginationContextProvider";
-import {Pagination} from "../Pagination/Pagination";
-import {Input} from "../input";
-import {Game} from "../Game/Game";
+import { useState, useEffect } from "react";
+import { GAME_INSTRUCTIONS } from "../../lib/constants";
+import { PaginationContextProvider } from "../Pagination/PaginationContextProvider";
+import { Pagination } from "../Pagination/Pagination";
+import { Input } from "../input";
+import { Game } from "../Game/Game";
 import useWeb3React from "../../hooks/use-web3-react";
 
 interface MiniGameProps {
@@ -11,19 +11,21 @@ interface MiniGameProps {
 }
 
 interface LeaderboardEntry {
+  id: string;
   wallet: string;
   score: number;
 }
 
-const MiniGame = ({terminal}: MiniGameProps) => {
-  const {state, startGame, updateGameScore, endGame, submitWalletAddress} =
+const MiniGame = ({ terminal }: MiniGameProps) => {
+  const { state, startGame, updateGameScore, endGame, submitWalletAddress } =
     terminal;
+  console.log("leaderboard", state.leaderboard);
   const [walletInput, setWalletInput] = useState("");
   const [showWalletInput, setShowWalletInput] = useState(false);
   const [walletError, setWalletError] = useState("");
   const [searchInput, setSearchInput] = useState("");
 
-  const {connect, account, disconnect, isConnected, isWalletLoading} =
+  const { connect, account, disconnect, isConnected, isWalletLoading } =
     useWeb3React();
 
   useEffect(() => {
@@ -167,10 +169,10 @@ const MiniGame = ({terminal}: MiniGameProps) => {
       {/* Leaderboard - 80s Highscore Table */}
       <PaginationContextProvider
         initialPage={1}
-        fetchData={async () => {}}
+        fetchData={async () => { }}
         pageSize={50}
       >
-        {({currentPage, setCurrentPage}) => (
+        {({ currentPage, setCurrentPage }) => (
           <>
             <div className="leaderboard mt-8 border-2 border-terminal-green p-2 bg-black/10">
               <div className="text-terminal-green font-bold mb-2 text-center border-b border-terminal-green pb-2 flex items-center justify-between relative">

--- a/libs/shared/ui/Terminal/Terminal.tsx
+++ b/libs/shared/ui/Terminal/Terminal.tsx
@@ -11,8 +11,8 @@ import CountdownTimer from "./CountdownTimer";
 import MiniGame from "./MiniGame";
 import { cn } from "../../utils/cn";
 
-const Terminal = () => {
-  const terminal = useTerminal();
+const Terminal = ({ leaderBoardData }: any) => {
+  const terminal = useTerminal(leaderBoardData);
   const { state, validatePassword, returnToTerminal } = terminal;
   const [passwordError, setPasswordError] = useState(false);
 

--- a/libs/shared/ui/Terminal/TerminalPage.tsx
+++ b/libs/shared/ui/Terminal/TerminalPage.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { queryClient } from '@/shared/lib/queryClient'
+import { QueryClientProvider } from '@tanstack/react-query'
+import FuelProviderWrapper from './FuelProviderWrapper'
+import Terminal from './Terminal'
+
+const TerminalPage = (leaderBoardData: any) => {
+    return (
+        <QueryClientProvider client={queryClient}>
+            <FuelProviderWrapper>
+                <div className="min-h-screen w-full flex items-center justify-center bg-black font-['VT323',monospace]">
+                    <Terminal leaderBoardData={leaderBoardData} />
+                </div>
+            </FuelProviderWrapper>
+        </QueryClientProvider>
+    )
+}
+
+export default TerminalPage


### PR DESCRIPTION
Server side leaderboard fetch

- [ ] Fetch leaderboard on server side and initialise client component
- [ ] Isolate and display walletAddress (currently displaying id in its place)
- [ ] Sort through all highscores (users can have multiple highscores - sort rank through multiple nested objects)
- [ ] Post high scores